### PR TITLE
Increasing cloud offset range and adding automated builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: 'Build'
+
+on:
+  push:
+    branches: *
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Use gradle cache for faster builds
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+      - name: Clean gradle
+        run: ./gradlew clean --no-daemon
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon --info
+      - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v2.2.2
+      with:
+        path: build/libs/**.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: 'Build'
 
 on:
   push:
-    branches: *
+    branches: main
 
 jobs:
   build:
@@ -26,6 +26,6 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build --no-daemon --info
       - name: Upload a Build Artifact
-      uses: actions/upload-artifact@v2.2.2
-      with:
-        path: build/libs/**.jar
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          path: build/libs/**.jar

--- a/src/main/java/codes/sana/cloudnine/client/CloudNineConfig.java
+++ b/src/main/java/codes/sana/cloudnine/client/CloudNineConfig.java
@@ -14,7 +14,7 @@ public class CloudNineConfig {
         CloudOffset = builder
                         .comment("Set the offset from the clouds default height of 128")
                         .translation("cloudnine.config.cloudOffset.title")
-                        .defineInRange("cloudnine.config.cloudOffset.value", 0, -100, 100);
+                        .defineInRange("cloudnine.config.cloudOffset.value", 0, -196, 192);
         return builder.build();
     }
 }

--- a/src/main/java/codes/sana/cloudnine/client/CloudNineConfigScreen.java
+++ b/src/main/java/codes/sana/cloudnine/client/CloudNineConfigScreen.java
@@ -57,7 +57,7 @@ public class CloudNineConfigScreen extends Screen {
         this.optionsRowList.addBig(new SliderPercentageOption(
             "cloudnine.config.cloudOffset.title",
             // Range: 0 to width of game window
-            -100.0, 100.0,
+            -196.0, 192.0,
             // This is an integer option, so allow whole steps only
             1.0F,
             // Getter and setter are similar to those in BooleanOption


### PR DESCRIPTION
Increasing cloud offset range so that the minimum places the top of the cloud layer at y = -64 and the maximum places the bottom of the cloud layer at y = 320

In other words, it will now be possible to put the cloud layer completely outside the build limits by 64 blocks in either direction. Useful in skyblock, oceanblock, and stoneblock worlds.

I made this change because I am working on an oceanblock pack and needed a mod to change only the cloud height because I'm using OTG for the terrain.

Mari ended up helping me when I wanted to test these changes, which is where the automated builds comes in.

I would greatly appreciate if you would merge at least the increased offset range, the build.yml was only for my own convenience, if you don't find it convenient it's not a necessary change.